### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Check


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/coinbase-wallet-sdk/security/code-scanning/20](https://github.com/Dargon789/coinbase-wallet-sdk/security/code-scanning/20)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's actions, the minimal required permission is `contents: read`, as the jobs primarily involve checking out the repository, setting up Node.js, and running commands like `yarn lint`, `yarn build`, and `yarn test`. These actions do not require write access to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Added root-level permissions block to workflow file with read-only access to contents