### PR TITLE
Update vercel-test.yml

### DIFF
--- a/.github/workflows/vercel-test.yml
+++ b/.github/workflows/vercel-test.yml
@@ -38,32 +38,48 @@ jobs:
 
       # 2. Set up Node.js.
       # The version should match the one in your project.
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x,20.x,22.x
-
+  steps:
+    - uses: actions/setup-node@v4
+    - name: Setup Node.js
+    - uses: actions/setup-node@v4
+      with:
+      node-version: 18.x,20.x,22.x
+  strategy:
+      matrix:
+      node-version: [18.x, 20.x, 22.x]
+      steps:
+      - uses: actions/setup-node@v4
+  with:
+      node-version: ${{ matrix.node-version }}
+      
       # 3. Install the Vercel CLI.
       # The Vercel CLI is the main tool for interacting with the Vercel platform.
-      - name: Install Vercel CLI
+      with:
+        node-version: 22.x
+        name: Install Vercel CLI
         run: npm install --global vercel@latest
 
       # 4. Pull Vercel project settings.
       # This fetches Vercel project links and Org ID.
-      - name: Pull Vercel environment variables
-        run: vercel pull --yes --environment=production
-        env:
+        with:  
+         - name: Pull Vercel environment variables
+      run: vercel pull --yes --environment=production
+      env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
       # 5. Build the project.
       # This command builds your project for a production environment.
       # It will automatically use the build command defined in your project's `package.json`.
-      - name: Build project
-        run: vercel build
+          with:
+          - name: Build project
+            run: vercel build
 
       # 6. Deploy the project to Vercel.
       # This step deploys the pre-built code to Vercel.
-      - name: Deploy to Vercel
-        run: vercel deploy --prebuilt
-        env:
+strategy:
+  matrix:
+    node-version: [18.x, 20.x, 22.x]
+    name: Deploy to Vercel
+    run: vercel deploy --prebuilt
+      env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

## Summary by Sourcery

Update the vercel-test GitHub Actions workflow to use setup-node v4 and introduce matrix testing across Node.js versions

Enhancements:
- Switch actions/setup-node usage to v4
- Add a strategy matrix for Node.js versions 18.x, 20.x, and 22.x to run setup, build, and deploy steps