### PR TITLE
Update playground.yml

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -18,20 +18,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: audit
-
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: yarn
       - name: Setup Pages
-        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
+        uses: actions/configure-pages@v4
         with:
           static_site_generator: next
       - name: Install dependencies
@@ -39,7 +34,7 @@ jobs:
       - name: Build and export with Next.js
         run: yarn deploy
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./examples/testapp/out
 
@@ -50,11 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
-        with:
-          egress-policy: audit
-
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
use playground.yml (#92)
https://github.com/Dargon789/coinbase-wallet-sdk/commit/b1a7b2e6c7b420b4b94c8577ed40549cc4edd19a

### _Summary_

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

## Summary by Sourcery

Update the playground GitHub Pages workflow to use newer Node and action versions while simplifying the job steps.

CI:
- Bump checkout, setup-node, configure-pages, upload-pages-artifact, and deploy-pages actions to their v4/v3 major versions and use tag-based refs instead of pinned SHAs.
- Increase the Node.js version used in the playground workflow from 20 to 22.
- Remove the step-security harden-runner auditing steps from the build and deploy jobs in the playground workflow.