### PR TITLE
feat(testapp): add COOP simulation toggle to eth_requestAccounts (#1888)

### DIFF
--- a/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
+++ b/examples/testapp/src/components/RpcMethods/RpcMethodCard.tsx
@@ -56,7 +56,7 @@ const replaceAddressInValue = async (value: any, getCurrentAddress: () => Promis
   return value;
 };
 
-export function RpcMethodCard({ format, method, params, shortcuts }) {
+export function RpcMethodCard({ format, method, params, shortcuts, children = null }) {
   const [response, setResponse] = React.useState<Response | null>(null);
   const [verifyResult, setVerifyResult] = React.useState<string | null>(null);
   const [error, setError] = React.useState<Record<string, unknown> | string | number | null>(null);
@@ -258,6 +258,7 @@ export function RpcMethodCard({ format, method, params, shortcuts }) {
             </Code>
           </VStack>
         )}
+        {children}
       </CardBody>
     </Card>
   );

--- a/examples/testapp/src/pages/index.page.tsx
+++ b/examples/testapp/src/pages/index.page.tsx
@@ -1,9 +1,11 @@
-import { Box, Container, Grid, Heading } from '@chakra-ui/react';
-import React, { useEffect } from 'react';
+import { Box, Container, Flex, Grid, GridItem, Heading, Switch, Text } from '@chakra-ui/react';
+import React, { useCallback, useEffect } from 'react';
 
 import { EventListenersCard } from '../components/EventListeners/EventListenersCard';
 import { WIDTH_2XL } from '../components/Layout';
 import { MethodsSection } from '../components/MethodsSection/MethodsSection';
+import { RpcMethodCard } from '../components/RpcMethods/RpcMethodCard';
+import { useConfig } from '../context/ConfigContextProvider';
 import { connectionMethods } from '../components/RpcMethods/method/connectionMethods';
 import { ephemeralMethods } from '../components/RpcMethods/method/ephemeralMethods';
 import { multiChainMethods } from '../components/RpcMethods/method/multiChainMethods';
@@ -23,6 +25,22 @@ import { useEIP1193Provider } from '../context/EIP1193ProviderContextProvider';
 
 export default function Home() {
   const { provider } = useEIP1193Provider();
+  const { scwUrl, setScwUrlAndSave } = useConfig();
+
+  const simulateCoop = new URL(scwUrl).searchParams.get('coop') === 'same-origin';
+
+  const handleSimulateCoopToggle = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const url = new URL(scwUrl);
+      if (e.target.checked) {
+        url.searchParams.set('coop', 'same-origin');
+      } else {
+        url.searchParams.delete('coop');
+      }
+      setScwUrlAndSave(url.toString() as Parameters<typeof setScwUrlAndSave>[0]);
+    },
+    [scwUrl, setScwUrlAndSave]
+  );
   // @ts-expect-error refactor soon
   const [connected, setConnected] = React.useState(Boolean(provider?.connected));
   const [chainId, setChainId] = React.useState<number | undefined>(undefined);
@@ -76,11 +94,40 @@ export default function Home() {
       <Box mt={4}>
         <SDKConfig />
       </Box>
-      <MethodsSection
-        title="Wallet Connection"
-        methods={connectionMethods}
-        shortcutsMap={connectionMethodShortcutsMap}
-      />
+      <Box mt={4}>
+        <Heading size="md">Wallet Connection</Heading>
+        <Grid
+          mt={2}
+          templateColumns={{ base: '100%', md: 'repeat(2, 50%)', xl: 'repeat(3, 33%)' }}
+          gap={2}
+        >
+          <GridItem w="100%" key="eth_requestAccounts">
+            <RpcMethodCard
+              method="eth_requestAccounts"
+              params={[]}
+              format={undefined}
+              shortcuts={connectionMethodShortcutsMap?.['eth_requestAccounts']}
+            >
+              <Flex align="center" justify="space-between" mt={4} pt={3} borderTopWidth={1}>
+                <Text fontSize="sm" fontWeight="medium">Simulate COOP</Text>
+                <Switch isChecked={simulateCoop} onChange={handleSimulateCoopToggle} />
+              </Flex>
+            </RpcMethodCard>
+          </GridItem>
+          {connectionMethods
+            .filter((rpc) => rpc.method !== 'eth_requestAccounts')
+            .map((rpc) => (
+              <GridItem w="100%" key={rpc.method}>
+                <RpcMethodCard
+                  method={rpc.method}
+                  params={rpc.params}
+                  format={rpc.format}
+                  shortcuts={connectionMethodShortcutsMap?.[rpc.method]}
+                />
+              </GridItem>
+            ))}
+        </Grid>
+      </Box>
       <MethodsSection
         title="Ephemeral Methods"
         methods={ephemeralMethods}

--- a/packages/wallet-sdk/src/util/web.test.ts
+++ b/packages/wallet-sdk/src/util/web.test.ts
@@ -68,13 +68,25 @@ describe('PopupManager', () => {
     url.searchParams.append('sdkVersion', VERSION);
     url.searchParams.append('origin', mockOrigin);
     url.searchParams.append('coop', 'null');
-    
+
     (window.open as Mock).mockReturnValue({ focus: vi.fn() });
 
     await openPopup(url);
 
     const paramCount = url.searchParams.toString().split('&').length;
     expect(paramCount).toBe(4);
+  });
+
+  it('should not overwrite coop=same-origin when already present in the URL', async () => {
+    const url = new URL('https://example.com');
+    url.searchParams.set('coop', 'same-origin');
+
+    (window.open as Mock).mockReturnValue({ focus: vi.fn() });
+
+    await openPopup(url);
+
+    expect(url.searchParams.get('coop')).toBe('same-origin');
+    expect(url.searchParams.getAll('coop')).toHaveLength(1);
   });
 
   it('should show snackbar with retry button when popup is blocked and retry successfully', async () => {


### PR DESCRIPTION
Adds a Simulate COOP toggle inside the eth_requestAccounts card. When
  enabled, simultaneously sets option to smartWalletOnly and keysUrl to
  localhost:3005/connect?coop=same-origin via ConfigContextProvider, so
  CoinbaseWalletProvider handles the popup directly bypassing injected
  extensions.

  RpcMethodCard gains a children prop to allow embedding extra UI inside
  any card's CardBody.

### _Summary_

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

## Summary by Sourcery

Add a COOP simulation option to the test app’s eth_requestAccounts flow and extend the RPC method card to support embedded UI while guarding popup behavior via tests.

New Features:
- Introduce a Simulate COOP toggle for eth_requestAccounts in the test app wallet connection UI.

Enhancements:
- Refine the wallet connection layout to render eth_requestAccounts separately from other connection methods.
- Extend RpcMethodCard to accept child content for injecting custom UI into method cards.

Tests:
- Add a PopupManager test ensuring an existing coop=same-origin query parameter is preserved and not duplicated in popup URLs.